### PR TITLE
philadelphia-coinbase: Remove transitive Philadelphia dependency

### DIFF
--- a/libraries/coinbase/README.md
+++ b/libraries/coinbase/README.md
@@ -23,8 +23,24 @@ Prime][Prime API] for the protocol specifications.
 
 Philadelphia Coinbase depends on the following libraries:
 
-- Philadelphia Core 1.2.0
-- Philadelphia FIX 4.2 1.2.0
+- Philadelphia Core 1.x
+- Philadelphia FIX 4.2 1.x
+
+If you do not already depend on Philadelphia Core 1.x and Philadelphia FIX 4.2
+1.x in your application, add Maven dependencies to them. For example:
+
+```xml
+<dependency>
+  <groupId>com.paritytrading.philadelphia</groupId>
+  <artifactId>philadelphia-core</artifactId>
+  <version>1.2.0</version>
+</dependency>
+<dependency>
+  <groupId>com.paritytrading.philadelphia</groupId>
+  <artifactId>philadelphia-fix42</artifactId>
+  <version>1.2.0</version>
+</dependency>
+```
 
 ## Download
 

--- a/libraries/coinbase/README.md
+++ b/libraries/coinbase/README.md
@@ -23,8 +23,8 @@ Prime][Prime API] for the protocol specifications.
 
 Philadelphia Coinbase depends on the following libraries:
 
-- Philadelphia Core 1.0.0
-- Philadelphia FIX 4.2 1.0.0
+- Philadelphia Core 1.2.0
+- Philadelphia FIX 4.2 1.2.0
 
 ## Download
 

--- a/libraries/coinbase/pom.xml
+++ b/libraries/coinbase/pom.xml
@@ -32,10 +32,12 @@
     <dependency>
       <groupId>com.paritytrading.philadelphia</groupId>
       <artifactId>philadelphia-core</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.paritytrading.philadelphia</groupId>
       <artifactId>philadelphia-fix42</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
-    <philadelphia.version>1.0.0</philadelphia.version> <!-- (mentioned in documentation) -->
+    <philadelphia.version>1.2.0</philadelphia.version> <!-- (mentioned in documentation) -->
   </properties>
 
   <modules>


### PR DESCRIPTION
Currently, Philadelphia Coinbase depends on Philadelphia Core 1.2.0 and Philadelphia FIX 4.2 1.2.0. This means that any application that has a dependency on this module also has transitive dependencies on those modules.

Replace transitive Philadelphia 1.2.0 dependencies with Philadelphia 1.x dependencies. This makes it possible for applications to manage their Philadelphia 1.x and Philadelphia Coinbase dependencies independently.

This also means that applications that use Philadelphia Coinbase need to have explicit dependencies on Philadelphia Core 1.x and Philadelphia FIX 4.2 1.x as well.