### PR TITLE
Improve 'maven-javadoc-plugin' configuration

### DIFF
--- a/libraries/coinbase/pom.xml
+++ b/libraries/coinbase/pom.xml
@@ -45,16 +45,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <doclint>all,-missing</doclint>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/libraries/ftx/pom.xml
+++ b/libraries/ftx/pom.xml
@@ -41,16 +41,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <doclint>all,-missing</doclint>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.4.1</version>
           <configuration>
+            <doclint>all,-missing</doclint>
             <failOnWarnings>true</failOnWarnings>
             <source>${java.version}</source>
           </configuration>


### PR DESCRIPTION
Fix the `javadoc:aggregate` goal when running Maven on Java 17.