### PR TITLE
Specify Java module names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 2.1.0 (????-??-??)
+
+- Specify Java module names (Jussi Virtanen)
+
+  Introduce minimal Java module support by specifying module names for all
+  libraries corresponding to their package names.
+
 ## 2.0.0 (2022-10-29)
 
 - Remove Cboe FX support (Jussi Virtanen)

--- a/UPGRADE-2.1.0.md
+++ b/UPGRADE-2.1.0.md
@@ -1,0 +1,29 @@
+# Upgrading to Philadelphia Extras 2.1.0
+
+Philadelphia Extras 2.1.0 contains a change in its Java module support.
+
+Philadelphia Extras 2.1.0 introduces rudimentary Java module support by setting
+module names fo all Philadelphia Extras libraries. These correspond to their
+package names. For example, the module name for Philadelphia Coinbase is:
+```
+com.paritytrading.philadelphia.coinbase
+```
+
+If you use Java modules in your application and currently reference
+Philadelphia Extras libraries using module names derived from their JAR names
+(as the JDK does by default), start using module names that correspond to their
+package names instead. See below for an example.
+
+Before:
+```java
+module example {
+    requires philadelphia.coinbase;
+}
+```
+
+After:
+```java
+module example {
+    requires com.paritytrading.philadelphia.coinbase;
+}
+```

--- a/libraries/coinbase/pom.xml
+++ b/libraries/coinbase/pom.xml
@@ -45,4 +45,20 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.paritytrading.philadelphia.coinbase</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,11 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.3.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.4.1</version>
           <configuration>


### PR DESCRIPTION
Introduce minimal Java module support by specifying module names for all libraries corresponding to their package names.