### PR TITLE
Improve Maven plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>1.8</java.version>
+    <java.version>8</java.version>
     <philadelphia.version>2.0.0</philadelphia.version> <!-- (mentioned in documentation) -->
   </properties>
 
@@ -192,6 +192,23 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>jdk-9-or-newer</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <release>${java.version}</release>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>release</id>
       <build>


### PR DESCRIPTION
`javac` prefers `8` rather than `1.8` these days. Set also the `release` paramater for `maven-compiler-plugin` to silence the following warning:

    [WARNING] bootstrap class path not set in conjunction with -source 8